### PR TITLE
Update website URL

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,7 +5,7 @@ articles:
   intro-spatsoc: intro-spatsoc.html
 
 destination: ../spatsoc.gitlab.io/public
-url: spatsoc.gitlab.io
+url: https://spatsoc.gitlab.io
 
 
 template:


### PR DESCRIPTION
The URL for pkgdown must contain the protocol and not just the domain name.