### PR TITLE
inconsistent blocks across years from group_times with threshold days

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests: testthat,
     rmarkdown,
     asnipe
 SystemRequirements: GEOS (>= 3.2.0)
-RoxygenNote: 6.1.0
+RoxygenNote: 6.1.1
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
 BugReports: https://github.com/ropensci/spatsoc/issues

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,16 @@
 # v 0.1.7 
+* fix inconsistent blocks across years ([PR #10](https://github.com/ropensci/spatsoc/pull/10))
+* update FAQ: remove old randomizations notes, clarify group_times block
 
 
 # v 0.1.6 (2019-01-10)
-* fix bug 'group_times misses nearest hour with mins threshold' (#5)
+* fix bug 'group_times misses nearest hour with mins threshold' ([#5](https://github.com/ropensci/spatsoc/issues/5) and [PR #6](https://github.com/ropensci/spatsoc/pull/6))
 
 # v 0.1.5
 * update issue labels and contributing
 * change over issue board location from GitLab to rOpenSci repository on GitHub
 * added preprint CITATION
-* added "https://" to `pkgdown` URL (#1)
+* added "https://" to `pkgdown` URL ([PR #1](https://github.com/ropensci/spatsoc/pull/1))
 
 # v 0.1.4 (2018-10-26)
 * fin [rOpenSci onboarding process](https://github.com/ropensci/onboarding/issues/237)

--- a/R/group_times.R
+++ b/R/group_times.R
@@ -242,12 +242,13 @@ group_times <- function(DT = NULL,
               ))
           )
         }
+
         dtm[, block := cut(
           data.table::yday(idate),
-          breaks = seq.int(minday[1], maxday[1] + nDays, by = nDays),
+          breaks = seq.int(minday, maxday + nDays, by = nDays),
           right = FALSE,
           labels = FALSE
-        ), by = year(idate)]
+        )]
 
         dtm[, timegroup := .GRP, .(year(idate), block)]
         set(dtm, j = c('idate', 'itime', 'rangeday', 'minday', 'maxday'),

--- a/R/group_times.R
+++ b/R/group_times.R
@@ -228,9 +228,9 @@ group_times <- function(DT = NULL,
         return(DT[])
       } else {
 
-        dtm[, minday := min(data.table::yday(idate)), by = year(idate)]
-        dtm[, maxday := max(data.table::yday(idate)), by = year(idate)]
-        dtm[, rangeday := maxday - minday, by = year(idate)]
+        minday <- dtm[, min(data.table::yday(idate))]
+        maxday <- dtm[, max(data.table::yday(idate))]
+        rangeday <- dtm[, maxday - minday]
 
         dtm[, block := cut(
           data.table::yday(idate),

--- a/R/group_times.R
+++ b/R/group_times.R
@@ -251,7 +251,7 @@ group_times <- function(DT = NULL,
         )]
 
         dtm[, timegroup := .GRP, .(year(idate), block)]
-        set(dtm, j = c('idate', 'itime', 'rangeday', 'minday', 'maxday'),
+        set(dtm, j = c('idate', 'itime'),
             value = NULL)
         DT[, (colnames(dtm)) := dtm]
         return(DT[])

--- a/R/group_times.R
+++ b/R/group_times.R
@@ -232,15 +232,7 @@ group_times <- function(DT = NULL,
         maxday <- dtm[, max(data.table::yday(idate))]
         rangeday <- dtm[, maxday - minday]
 
-        dtm[, block := cut(
-          data.table::yday(idate),
-          breaks = seq.int(minday[1], maxday[1] + nDays, by = nDays),
-          right = FALSE,
-          labels = FALSE
-        ), by = year(idate)]
-        dtm[, timegroup := .GRP, .(year(idate), block)]
-
-        if (any(!(dtm[, unique(rangeday)] %% nDays == 0))) {
+        if (!(rangeday %% nDays == 0)) {
           warning(
             strwrap(
               prefix = " ",

--- a/codemeta.json
+++ b/codemeta.json
@@ -20,10 +20,10 @@
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
-    "version": "3.5.2",
+    "version": "3.5.3",
     "url": "https://r-project.org"
   },
-  "runtimePlatform": "R version 3.5.2 (2018-12-20)",
+  "runtimePlatform": "R version 3.5.3 (2019-03-11)",
   "provider": {
     "@id": "https://cran.r-project.org",
     "@type": "Organization",
@@ -223,7 +223,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/spatsoc//blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/spatsoc/blob/master/README.md",
-  "fileSize": "395.952KB",
+  "fileSize": "396.244KB",
   "contIntegration": "https://codecov.io/gl/robit.a/spatsoc",
   "developmentStatus": "http://www.repostatus.org/#active",
   "review": {
@@ -237,7 +237,9 @@
     "social",
     "gps",
     "animal",
-    "network"
+    "network",
+    "r-package",
+    "rstats"
   ],
   "contributor": {},
   "copyrightHolder": {},

--- a/tests/testthat/test-time.R
+++ b/tests/testthat/test-time.R
@@ -290,3 +290,18 @@ test_that('group_times nearest hour with minutes threshold', {
     3)
 
 })
+
+
+test_that('timegroups are based off years but blocks are consistent across all years', {
+  copyDT <- copy(DT)
+  copyDT[, datetime := as.POSIXct(datetime)]
+  suppressWarnings(group_times(copyDT, 'datetime', '10 days'))
+  blocks <- copyDT[, as.list(range(yday(datetime))),
+                   .(block, year(datetime))]
+  setkey(blocks, V1, V2)
+  expect_true(
+    nrow(foverlaps(blocks, blocks)) == nrow(blocks)
+  )
+
+  # need multi year data for same jul days to test if n years by block > 1, but n years by timegroup == 1
+})

--- a/vignettes/faq.Rmd
+++ b/vignettes/faq.Rmd
@@ -123,7 +123,7 @@ The `threshold` provided to `group_times` should be related to the fix rate of t
 The `threshold` of `group_times` is considered only within the scope of 24 hours and this poses limitations on it:
 
 * `threshold` must evenly divide into 60 minutes or 24 hours
-* multi-day blocks should divide evenly into the range of days in the `DT`
+* multi-day blocks are consistent **across years** and timegroups from these are **by year**. 
 * number of minutes cannot exceed 60
 * `threshold` cannot be fractional
 
@@ -149,6 +149,10 @@ This message is returned to the user when a column matching those returned by `g
 * "no threshold provided, using the time field directly to group"
 
 This message is returned to the user when the `threshold` is NULL. This is the default setting of `threshold` and, at times, may be suitable. In this case, the date times in the `datetime` column will be grouped exactly. Usually, a threshold should be provided. 
+
+* "the minimum and maximum days in DT are not evenly divisible by the provided block length"
+
+This warning is returned to the user when the `threshold` with unit days does not divide evenly into the range of days in DT. For example, if DT had data covering 30 days, and a threshold of '7 days' was used, this warning would be returned. Note, this warning is returned for the range of days for the entire data set and not by year. 
 
 ## group_pts
 


### PR DESCRIPTION
If the threshold is days (e.g. 10 days), the blocks returned are calculated by year (like timegroup), resulting in inconsistent blocks across years. 


![](https://user-images.githubusercontent.com/16324625/55019287-d867d580-4fb1-11e9-9b43-3d0e54ea20e3.png)


This doesn't seem ideal (let us know if you disagree!). Timegroups will continue to be by block and year, but blocks will be consistent across years. 


