### PR TITLE
randomization number of ids per iteration

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spatsoc
 Title: Group Animal Relocation Data by Spatial and Temporal Relationship
-Version: 0.1.8
+Version: 0.1.9
 Authors@R: 
     c(person(given = "Alec L.",
              family = "Robitaille",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,4 +1,9 @@
-# v 0.1.8
+# v 0.1.9 
+* fixed bug for randomizations type 'step' and 'daily' ([PR 13](https://github.com/ropensci/spatsoc/pull/13)). 
+* clarified `SIMPLIFY=FALSE` in SNA vignette. 
+
+
+# v 0.1.8 (2019-04-05)
 * update [FAQ](http://spatsoc.robitalec.ca/articles/faq.html) and [Introduction to spatsoc](http://spatsoc.robitalec.ca/articles/intro-spatsoc.html) vignettes adding entries for edge list generating functions. 
 * added edge list generating function `edge_nn` ([PR 11](https://github.com/ropensci/spatsoc/pull/12))
 * added edge list generating function `edge_dist` ([PR 11](https://github.com/ropensci/spatsoc/pull/11))

--- a/R/randomizations.R
+++ b/R/randomizations.R
@@ -230,21 +230,29 @@ randomizations <- function(DT = NULL,
 
     repDT[!(observed), randomID := .SD[sample(.N, size = .N)],
           by = splitBy, .SDcols = id]
+
     repDT[(observed), randomID := .SD, .SDcols = id]
+
     return(repDT)
   }
 
   repDT[, jul := data.table::yday(.SD[[1]]), .SDcols = datetime]
-  idDays <- unique(repDT[, .SD,
-                         .SDcols = c(splitBy, id, 'jul',
-                                     'iteration', 'observed')])
+  idDays <- unique(
+    repDT[, .SD, .SDcols = c(splitBy, id, 'jul', 'iteration', 'observed')]
+  )
 
   if (type == 'daily') {
-    idDays[, randomID := .SD[sample(.N, size = .N)],
-           by = c(splitBy, 'jul'), .SDcols = id]
+    if (is.null(splitBy)) {
+      splitBy <- c('jul', 'iteration')
+    } else {
+      splitBy <- c('jul', 'iteration', splitBy)
+    }
+
+
+    idDays[, randomID := .SD[sample(.N, size = .N)], by = splitBy, .SDcols = id]
     idDays[(observed), randomID := .SD[[1]], .SDcols = id]
-    return(merge(repDT, idDays, on = c('iteration', 'jul', splitBy),
-                 all = TRUE))
+
+    return(merge(repDT, idDays, on = splitBy, all = TRUE))
 
   } else if (type == 'trajectory') {
     idDays[, randomJul := sample(jul, size = .N),

--- a/R/randomizations.R
+++ b/R/randomizations.R
@@ -228,7 +228,7 @@ randomizations <- function(DT = NULL,
       splitBy <- c(datetime, splitBy)
     }
 
-    repDT[!(observed), randomID := .SD[sample(.N)],
+    repDT[!(observed), randomID := .SD[sample(.N, size = .N)],
           by = splitBy, .SDcols = id]
     repDT[(observed), randomID := .SD, .SDcols = id]
     return(repDT)
@@ -240,14 +240,14 @@ randomizations <- function(DT = NULL,
                                      'iteration', 'observed')])
 
   if (type == 'daily') {
-    idDays[, randomID := .SD[sample(.N)],
+    idDays[, randomID := .SD[sample(.N, size = .N)],
            by = c(splitBy, 'jul'), .SDcols = id]
     idDays[(observed), randomID := .SD[[1]], .SDcols = id]
     return(merge(repDT, idDays, on = c('iteration', 'jul', splitBy),
                  all = TRUE))
 
   } else if (type == 'trajectory') {
-    idDays[, randomJul := sample(jul),
+    idDays[, randomJul := sample(jul, size = .N),
            by = c(id, splitBy, 'iteration')]
     merged <- merge(repDT, idDays,
                     on = c('jul', id, 'iteration', splitBy),

--- a/R/randomizations.R
+++ b/R/randomizations.R
@@ -223,9 +223,9 @@ randomizations <- function(DT = NULL,
 
   if (type == 'step') {
     if (is.null(splitBy)) {
-      splitBy <- datetime
+      splitBy <- c(datetime, 'iteration')
     } else {
-      splitBy <- c(datetime, splitBy)
+      splitBy <- c(datetime, 'iteration', splitBy)
     }
 
     repDT[!(observed), randomID := .SD[sample(.N, size = .N)],

--- a/R/randomizations.R
+++ b/R/randomizations.R
@@ -212,7 +212,7 @@ randomizations <- function(DT = NULL,
   repDT[, rowID := .GRP, by = selCols]
 
   if (any(repDT[, .N , by = rowID]$N != iterations + 1)) {
-    warning('found none unique rows of id, datetime (and splitBy)')
+    warning('found non-unique rows of id, datetime (and splitBy)')
   }
 
   repDT[, iteration := seq(0, .N - 1, 1), by = rowID]

--- a/codemeta.json
+++ b/codemeta.json
@@ -17,7 +17,7 @@
   ],
   "issueTracker": "https://github.com/ropensci/spatsoc/issues",
   "license": "https://spdx.org/licenses/GPL-3.0",
-  "version": "0.1.8",
+  "version": "0.1.9",
   "programmingLanguage": {
     "@type": "ComputerLanguage",
     "name": "R",
@@ -224,7 +224,7 @@
   ],
   "releaseNotes": "https://github.com/ropensci/spatsoc//blob/master/NEWS.md",
   "readme": "https://github.com/ropensci/spatsoc/blob/master/README.md",
-  "fileSize": "365.859KB",
+  "fileSize": "366.33KB",
   "contIntegration": "https://codecov.io/gl/robit.a/spatsoc",
   "developmentStatus": "http://www.repostatus.org/#active",
   "review": {

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -225,7 +225,7 @@ test_that('non uniques are found', {
                                 group = 'group',
                                 datetime = 'datetime',
                                 iterations = 2),
-                 'found none unique rows of id, datetime',
+                 'found non-unique rows of id, datetime',
                  fixed = FALSE)
 })
 

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -8,8 +8,13 @@ DT[, datetime := as.POSIXct(datetime)]
 DT[, yr := year(datetime)]
 
 group_times(DT, datetime = 'datetime', threshold = '1 hour')
-group_pts(DT, threshold = 100, id = 'ID', timegroup = 'timegroup',
-        coords = c('X', 'Y'))
+group_pts(
+  DT,
+  threshold = 100,
+  id = 'ID',
+  timegroup = 'timegroup',
+  coords = c('X', 'Y')
+)
 
 test_that('DT, type, id, datetime, (group) are required', {
   expect_error(randomizations(DT = NULL),
@@ -363,3 +368,44 @@ test_that('randomization is silent when an individual only has one row', {
 })
 
 
+
+test_that('n individuals consistent across years', {
+  DT[1, ID := 'Z']
+
+  ## Step
+  randStep <- randomizations(
+    DT,
+    type = 'step',
+    id = 'ID',
+    group = 'group',
+    splitBy = 'yr',
+    datetime = 'timegroup',
+    iterations = 20
+  )
+
+  uID <- randStep[, .(nID = .N), by = .(randomID, yr, iteration)]
+
+  expect_equal(
+    uID[, sd(nID), by = .(randomID, yr)]$V1,
+    rep(0, randStep[, uniqueN(randomID)])
+  )
+
+  ## Daily
+  randDaily <- randomizations(
+    DT,
+    type = 'daily',
+    id = 'ID',
+    group = 'group',
+    splitBy = 'yr',
+    datetime = 'datetime',
+    iterations = 20
+  )
+
+  uID <- randDaily[, .(nID = .N), by = .(randomID, yr, iteration)]
+
+  expect_equal(
+    uID[, sd(nID), by = .(randomID, yr)]$V1,
+    rep(0, randDaily[, uniqueN(randomID)])
+  )
+
+})

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -302,3 +302,64 @@ test_that('randomization returns expected columns', {
 })
 
 
+
+
+
+test_that('randomization is silent when an individual only has one row', {
+  ## Fixed here: 6092ad8d055ff269d39dd481a80f27069c790630
+
+  # ** Fake an individual with 1 relocation**
+  copyDT <- copy(DT)[1, ID := 'Z']
+
+  # Temporal grouping
+  group_times(copyDT, datetime = 'datetime', threshold = '5 minutes')
+
+  # Spatial grouping with timegroup
+  group_pts(
+    copyDT,
+    threshold = 5,
+    id = 'ID',
+    coords = c('X', 'Y'),
+    timegroup = 'timegroup'
+  )
+
+  expect_silent(
+    randomizations(
+      copyDT,
+      type = 'step',
+      id = 'ID',
+      group = 'group',
+      datetime = 'timegroup',
+      splitBy = 'yr',
+      iterations = 2
+    )
+  )
+
+  expect_silent(
+    randomizations(
+      copyDT,
+      type = 'daily',
+      id = 'ID',
+      group = 'group',
+      datetime = 'datetime',
+      splitBy = 'yr',
+      iterations = 2
+    )
+  )
+
+  expect_silent(
+    randomizations(
+      copyDT,
+      type = 'trajectory',
+      id = 'ID',
+      group = NULL,
+      coords = c('X', 'Y'),
+      datetime = 'datetime',
+      splitBy = 'yr',
+      iterations = 2
+    )
+  )
+
+})
+
+

--- a/tests/testthat/test-random.R
+++ b/tests/testthat/test-random.R
@@ -400,12 +400,11 @@ test_that('n individuals consistent across years', {
     datetime = 'datetime',
     iterations = 20
   )
-
-  uID <- randDaily[, .(nID = .N), by = .(randomID, yr, iteration)]
+  uJul <- randDaily[, .(nDay = uniqueN(jul)), by = .(randomID, yr, iteration)]
 
   expect_equal(
-    uID[, sd(nID), by = .(randomID, yr)]$V1,
-    rep(0, randDaily[, uniqueN(randomID)])
+    uJul[, sd(nDay), by = .(randomID, yr)]$V1,
+    rep(0, nrow(randDaily[, .N, .(randomID, yr)]))
   )
 
 })


### PR DESCRIPTION
Bug found in `randomizations` where the number of individuals across iterations differs. A bit tricky to notice with large number of relocations for individuals but stands out when an individual only has a few relocations. (Thanks for spotting this @qwebber).
