### PR TITLE
Enhancement/drop timegroup null

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -12,3 +12,5 @@
 ^CODE_OF_CONDUCT\.md$
 ^CONTRIBUTING\.md$
 Makefile
+^doc$
+^Meta$

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 .RData
 .Ruserdata
 inst/doc
+doc
+Meta

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ Suggests: testthat,
     rmarkdown,
     asnipe
 SystemRequirements: GEOS (>= 3.2.0)
-RoxygenNote: 6.1.1
+RoxygenNote: 7.0.2
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
 BugReports: https://github.com/ropensci/spatsoc/issues

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spatsoc
 Title: Group Animal Relocation Data by Spatial and Temporal Relationship
-Version: 0.1.10
+Version: 0.1.11
 Authors@R: 
     c(person(given = "Alec L.",
              family = "Robitaille",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# v 0.1.11
+* removed default NULL from 'timegroup' arguments in `group_pts`, `edge_dist` and `edge_nn` ([PR 21](https://github.com/ropensci/spatsoc/pull/24))
+
+
 # v 0.1.10
 * added optional return of distance between individuals with `edge_dist` ([PR 19](https://github.com/ropensci/spatsoc/pull/19)) and `edge_nn` ([PR 21](https://github.com/ropensci/spatsoc/pull/21))
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,8 +1,8 @@
-# v 0.1.11
+# v 0.1.11 (2020-02-20)
 * removed default NULL from 'timegroup' arguments in `group_pts`, `edge_dist` and `edge_nn` ([PR 21](https://github.com/ropensci/spatsoc/pull/24))
 
 
-# v 0.1.10
+# v 0.1.10 (2019-06-06)
 * added optional return of distance between individuals with `edge_dist` ([PR 19](https://github.com/ropensci/spatsoc/pull/19)) and `edge_nn` ([PR 21](https://github.com/ropensci/spatsoc/pull/21))
 
 

--- a/R/edge_dist.R
+++ b/R/edge_dist.R
@@ -77,6 +77,10 @@ edge_dist <- function(DT = NULL,
     stop('coords requires a vector of column names for coordinates X and Y')
   }
 
+  if (missing(timegroup)) {
+    stop('timegroup required')
+  }
+
   if (any(!(
     c(timegroup, id, coords, splitBy) %in% colnames(DT)
   ))) {

--- a/R/edge_dist.R
+++ b/R/edge_dist.R
@@ -46,7 +46,7 @@ edge_dist <- function(DT = NULL,
                       threshold = NULL,
                       id = NULL,
                       coords = NULL,
-                      timegroup = NULL,
+                      timegroup,
                       splitBy = NULL,
                       returnDist = FALSE,
                       fillNA = TRUE) {

--- a/R/edge_nn.R
+++ b/R/edge_nn.R
@@ -57,7 +57,7 @@
 edge_nn <- function(DT = NULL,
                     id = NULL,
                     coords = NULL,
-                    timegroup = NULL,
+                    timegroup,
                     splitBy = NULL,
                     threshold = NULL,
                     returnDist = FALSE) {

--- a/R/edge_nn.R
+++ b/R/edge_nn.R
@@ -86,6 +86,10 @@ edge_nn <- function(DT = NULL,
     stop('coords requires a vector of column names for coordinates X and Y')
   }
 
+  if (missing(timegroup)) {
+    stop('timegroup required')
+  }
+
   if (any(!(
     c(timegroup, id, coords, splitBy) %in% colnames(DT)
   ))) {
@@ -112,9 +116,9 @@ edge_nn <- function(DT = NULL,
           x = 'timegroup provided is a date/time
           or character type, did you use group_times?'
         )
-        )
+      )
     }
-    }
+  }
 
   if (is.null(timegroup) && is.null(splitBy)) {
     splitBy <- NULL
@@ -129,9 +133,9 @@ edge_nn <- function(DT = NULL,
           timegroup and/or splitBy -
           does your group_times threshold match the fix rate?'
         )
-        )
+      )
     }
-    }
+  }
 
   DT[, {
 

--- a/R/group_pts.R
+++ b/R/group_pts.R
@@ -23,7 +23,7 @@
 #' @param threshold distance for grouping points, in the units of the coordinates
 #' @param id Character string of ID column name
 #' @param coords Character vector of X coordinate and Y coordinate column names
-#' @param timegroup (optional) timegroup field in the DT upon which the grouping will be calculated
+#' @param timegroup timegroup field in the DT upon which the grouping will be calculated
 #' @param splitBy (optional) character string or vector of grouping column name(s) upon which the grouping will be calculated
 #'
 #' @export

--- a/R/group_pts.R
+++ b/R/group_pts.R
@@ -83,6 +83,10 @@ group_pts <- function(DT = NULL,
     stop('coords requires a vector of column names for coordinates X and Y')
   }
 
+  if (missing(timegroup)) {
+    stop('timegroup required')
+  }
+
   if (any(!(
     c(timegroup, id, coords, splitBy) %in% colnames(DT)
   ))) {

--- a/R/group_pts.R
+++ b/R/group_pts.R
@@ -54,7 +54,7 @@ group_pts <- function(DT = NULL,
                      threshold = NULL,
                      id = NULL,
                      coords = NULL,
-                     timegroup = NULL,
+                     timegroup,
                      splitBy = NULL) {
   # due to NSE notes in R CMD check
   N <- withinGroup <- ..id <- ..coords <- group <- NULL

--- a/man/build_lines.Rd
+++ b/man/build_lines.Rd
@@ -4,8 +4,14 @@
 \alias{build_lines}
 \title{Build Lines}
 \usage{
-build_lines(DT = NULL, projection = NULL, id = NULL, coords = NULL,
-  sortBy = NULL, splitBy = NULL)
+build_lines(
+  DT = NULL,
+  projection = NULL,
+  id = NULL,
+  coords = NULL,
+  sortBy = NULL,
+  splitBy = NULL
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -67,6 +73,7 @@ build_lines(DT, projection = utm, id = 'ID', coords = c('X', 'Y'),
 \seealso{
 \code{\link{group_lines}}
 
-Other Build functions: \code{\link{build_polys}}
+Other Build functions: 
+\code{\link{build_polys}()}
 }
 \concept{Build functions}

--- a/man/build_polys.Rd
+++ b/man/build_polys.Rd
@@ -4,9 +4,16 @@
 \alias{build_polys}
 \title{Build Polygons}
 \usage{
-build_polys(DT = NULL, projection = NULL, hrType = NULL,
-  hrParams = NULL, id = NULL, coords = NULL, splitBy = NULL,
-  spPts = NULL)
+build_polys(
+  DT = NULL,
+  projection = NULL,
+  hrType = NULL,
+  hrParams = NULL,
+  id = NULL,
+  coords = NULL,
+  splitBy = NULL,
+  spPts = NULL
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -82,6 +89,7 @@ build_polys(spPts = pts, hrType = 'mcp', hrParams = list(percent = 95))
 \seealso{
 \code{\link{group_polys}}
 
-Other Build functions: \code{\link{build_lines}}
+Other Build functions: 
+\code{\link{build_lines}()}
 }
 \concept{Build functions}

--- a/man/edge_dist.Rd
+++ b/man/edge_dist.Rd
@@ -17,7 +17,7 @@ edge_dist(DT = NULL, threshold = NULL, id = NULL, coords = NULL,
 
 \item{coords}{Character vector of X coordinate and Y coordinate column names}
 
-\item{timegroup}{(optional) timegroup field in the DT upon which the grouping will be calculated}
+\item{timegroup}{timegroup field in the DT upon which the grouping will be calculated}
 
 \item{splitBy}{(optional) character string or vector of grouping column name(s) upon which the grouping will be calculated}
 

--- a/man/edge_dist.Rd
+++ b/man/edge_dist.Rd
@@ -4,9 +4,16 @@
 \alias{edge_dist}
 \title{Distance based edge lists}
 \usage{
-edge_dist(DT = NULL, threshold = NULL, id = NULL, coords = NULL,
-  timegroup = NULL, splitBy = NULL, returnDist = FALSE,
-  fillNA = TRUE)
+edge_dist(
+  DT = NULL,
+  threshold = NULL,
+  id = NULL,
+  coords = NULL,
+  timegroup,
+  splitBy = NULL,
+  returnDist = FALSE,
+  fillNA = TRUE
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -62,6 +69,7 @@ edge_dist(DT, threshold = 100, id = 'ID',
           coords = c('X', 'Y'), timegroup = 'timegroup', returnDist = TRUE, fillNA = TRUE)
 }
 \seealso{
-Other Edge-list generation: \code{\link{edge_nn}}
+Other Edge-list generation: 
+\code{\link{edge_nn}()}
 }
 \concept{Edge-list generation}

--- a/man/edge_nn.Rd
+++ b/man/edge_nn.Rd
@@ -14,7 +14,7 @@ edge_nn(DT = NULL, id = NULL, coords = NULL, timegroup = NULL,
 
 \item{coords}{Character vector of X coordinate and Y coordinate column names}
 
-\item{timegroup}{(optional) timegroup field in the DT upon which the grouping will be calculated}
+\item{timegroup}{timegroup field in the DT upon which the grouping will be calculated}
 
 \item{splitBy}{(optional) character string or vector of grouping column name(s) upon which the grouping will be calculated}
 

--- a/man/edge_nn.Rd
+++ b/man/edge_nn.Rd
@@ -4,8 +4,15 @@
 \alias{edge_nn}
 \title{Nearest neighbour based edge lists}
 \usage{
-edge_nn(DT = NULL, id = NULL, coords = NULL, timegroup = NULL,
-  splitBy = NULL, threshold = NULL, returnDist = FALSE)
+edge_nn(
+  DT = NULL,
+  id = NULL,
+  coords = NULL,
+  timegroup,
+  splitBy = NULL,
+  threshold = NULL,
+  returnDist = FALSE
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -71,6 +78,7 @@ edge_nn(DT, id = 'ID', coords = c('X', 'Y'),
 
 }
 \seealso{
-Other Edge-list generation: \code{\link{edge_dist}}
+Other Edge-list generation: 
+\code{\link{edge_dist}()}
 }
 \concept{Edge-list generation}

--- a/man/get_gbi.Rd
+++ b/man/get_gbi.Rd
@@ -52,6 +52,7 @@ gbiMtrx <- get_gbi(DT = DT, group = 'group', id = 'ID')
 \seealso{
 \code{\link{group_pts}} \code{\link{group_lines}} \code{\link{group_polys}}
 
-Other Social network tools: \code{\link{randomizations}}
+Other Social network tools: 
+\code{\link{randomizations}()}
 }
 \concept{Social network tools}

--- a/man/group_lines.Rd
+++ b/man/group_lines.Rd
@@ -20,7 +20,7 @@ of the projection. Supply 0 to compare intersection without buffering.}
 
 \item{coords}{Character vector of X coordinate and Y coordinate column names}
 
-\item{timegroup}{(optional) timegroup field in the DT upon which the grouping will be calculated}
+\item{timegroup}{timegroup field in the DT upon which the grouping will be calculated}
 
 \item{sortBy}{Character string of date time column(s) to sort rows by. Must be a POSIXct.}
 

--- a/man/group_lines.Rd
+++ b/man/group_lines.Rd
@@ -4,9 +4,17 @@
 \alias{group_lines}
 \title{Groups Lines}
 \usage{
-group_lines(DT = NULL, threshold = NULL, projection = NULL,
-  id = NULL, coords = NULL, timegroup = NULL, sortBy = NULL,
-  splitBy = NULL, spLines = NULL)
+group_lines(
+  DT = NULL,
+  threshold = NULL,
+  projection = NULL,
+  id = NULL,
+  coords = NULL,
+  timegroup = NULL,
+  sortBy = NULL,
+  splitBy = NULL,
+  spLines = NULL
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -92,7 +100,8 @@ group_lines(DT, threshold = 50, projection = utm,
 \seealso{
 \code{\link{build_lines}} \code{\link{group_times}}
 
-Other Spatial grouping: \code{\link{group_polys}},
-  \code{\link{group_pts}}
+Other Spatial grouping: 
+\code{\link{group_polys}()},
+\code{\link{group_pts}()}
 }
 \concept{Spatial grouping}

--- a/man/group_polys.Rd
+++ b/man/group_polys.Rd
@@ -4,9 +4,17 @@
 \alias{group_polys}
 \title{Group Polygons}
 \usage{
-group_polys(DT = NULL, area = NULL, hrType = NULL, hrParams = NULL,
-  projection = NULL, id = NULL, coords = NULL, splitBy = NULL,
-  spPolys = NULL)
+group_polys(
+  DT = NULL,
+  area = NULL,
+  hrType = NULL,
+  hrParams = NULL,
+  projection = NULL,
+  id = NULL,
+  coords = NULL,
+  splitBy = NULL,
+  spPolys = NULL
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -70,7 +78,8 @@ areaDT <- group_polys(DT, area = TRUE, 'mcp', list(percent = 95),
 \seealso{
 \code{\link{build_polys}} \code{\link{group_times}}
 
-Other Spatial grouping: \code{\link{group_lines}},
-  \code{\link{group_pts}}
+Other Spatial grouping: 
+\code{\link{group_lines}()},
+\code{\link{group_pts}()}
 }
 \concept{Spatial grouping}

--- a/man/group_pts.Rd
+++ b/man/group_pts.Rd
@@ -4,8 +4,14 @@
 \alias{group_pts}
 \title{Group Points}
 \usage{
-group_pts(DT = NULL, threshold = NULL, id = NULL, coords = NULL,
-  timegroup = NULL, splitBy = NULL)
+group_pts(
+  DT = NULL,
+  threshold = NULL,
+  id = NULL,
+  coords = NULL,
+  timegroup,
+  splitBy = NULL
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -16,7 +22,7 @@ group_pts(DT = NULL, threshold = NULL, id = NULL, coords = NULL,
 
 \item{coords}{Character vector of X coordinate and Y coordinate column names}
 
-\item{timegroup}{(optional) timegroup field in the DT upon which the grouping will be calculated}
+\item{timegroup}{timegroup field in the DT upon which the grouping will be calculated}
 
 \item{splitBy}{(optional) character string or vector of grouping column name(s) upon which the grouping will be calculated}
 }
@@ -64,7 +70,8 @@ group_pts(DT, threshold = 5, id = 'ID', coords = c('X', 'Y'),
 \seealso{
 \code{\link{group_times}}
 
-Other Spatial grouping: \code{\link{group_lines}},
-  \code{\link{group_polys}}
+Other Spatial grouping: 
+\code{\link{group_lines}()},
+\code{\link{group_polys}()}
 }
 \concept{Spatial grouping}

--- a/man/randomizations.Rd
+++ b/man/randomizations.Rd
@@ -4,9 +4,16 @@
 \alias{randomizations}
 \title{Data-stream randomizations}
 \usage{
-randomizations(DT = NULL, type = NULL, id = NULL, group = NULL,
-  coords = NULL, datetime = NULL, splitBy = NULL,
-  iterations = NULL)
+randomizations(
+  DT = NULL,
+  type = NULL,
+  id = NULL,
+  group = NULL,
+  coords = NULL,
+  datetime = NULL,
+  splitBy = NULL,
+  iterations = NULL
+)
 }
 \arguments{
 \item{DT}{input data.table}
@@ -134,6 +141,7 @@ randTraj <- randomizations(
 \url{http://onlinelibrary.wiley.com/doi/10.1111/2041-210X.12553/full}
 }
 \seealso{
-Other Social network tools: \code{\link{get_gbi}}
+Other Social network tools: 
+\code{\link{get_gbi}()}
 }
 \concept{Social network tools}

--- a/man/spatsoc.Rd
+++ b/man/spatsoc.Rd
@@ -40,17 +40,18 @@ Useful links:
 \itemize{
   \item \url{http://spatsoc.robitalec.ca}
   \item \url{https://github.com/ropensci/spatsoc}
+  \item \url{https://docs.ropensci.org/spatsoc/}
   \item Report bugs at \url{https://github.com/ropensci/spatsoc/issues}
 }
 
 }
 \author{
-\strong{Maintainer}: Alec L. Robitaille \email{robit.alec@gmail.com} (0000-0002-4706-1762)
+\strong{Maintainer}: Alec L. Robitaille \email{robit.alec@gmail.com} (\href{https://orcid.org/0000-0002-4706-1762}{ORCID})
 
 Authors:
 \itemize{
-  \item Quinn Webber (0000-0002-0434-9360)
-  \item Eric Vander Wal (0000-0002-8534-4317)
+  \item Quinn Webber (\href{https://orcid.org/0000-0002-0434-9360}{ORCID})
+  \item Eric Vander Wal (\href{https://orcid.org/0000-0002-8534-4317}{ORCID})
 }
 
 }

--- a/tests/testthat/test-edge-dist.R
+++ b/tests/testthat/test-edge-dist.R
@@ -129,7 +129,7 @@ test_that('coords are correctly provided or error detected', {
       threshold = 10,
       id = 'ID',
       coords = c('X', 'ID'),
-      timegroup = 'timegroup'
+      timegroup = NULL
     ),
     'coords must be numeric'
   )

--- a/tests/testthat/test-edge-dist.R
+++ b/tests/testthat/test-edge-dist.R
@@ -41,7 +41,8 @@ test_that('column names must exist in DT', {
       DT,
       threshold = 10,
       id = 'potato',
-      coords = c('X', 'Y')
+      coords = c('X', 'Y'),
+      timegroup = 'timegroup'
     ),
     'not present in input DT',
     fixed = FALSE
@@ -53,7 +54,8 @@ test_that('column names must exist in DT', {
       DT,
       threshold = 10,
       id = 'ID',
-      coords = c('potatoX', 'potatoY')
+      coords = c('potatoX', 'potatoY'),
+      timegroup = 'timegroup'
     ),
     'not present in input DT',
     fixed = FALSE
@@ -66,6 +68,7 @@ test_that('column names must exist in DT', {
       threshold = 10,
       id = 'ID',
       coords = c('X', 'Y'),
+      timegroup = 'timegroup',
       splitBy = 'potato'
     ),
     'not present in input DT',
@@ -93,7 +96,8 @@ test_that('threshold correctly provided or error detected', {
     copyDT,
     threshold = 10,
     id = 'ID',
-    coords = c('X', 'Y')
+    coords = c('X', 'Y'),
+    timegroup = NULL
   ))
 
   expect_error(edge_dist(DT, threshold = -10, id = 'ID'),
@@ -113,7 +117,8 @@ test_that('coords are correctly provided or error detected', {
       DT,
       threshold = 10,
       id = 'ID',
-      coords = c('X', NULL)
+      coords = c('X', NULL),
+      timegroup = 'timegroup'
     ),
     'coords requires a vector'
   )
@@ -123,7 +128,8 @@ test_that('coords are correctly provided or error detected', {
       DT,
       threshold = 10,
       id = 'ID',
-      coords = c('X', 'ID')
+      coords = c('X', 'ID'),
+      timegroup = 'timegroup'
     ),
     'coords must be numeric'
   )

--- a/tests/testthat/test-edge-nn.R
+++ b/tests/testthat/test-edge-nn.R
@@ -36,7 +36,8 @@ test_that('column names must exist in DT', {
     edge_nn(
       DT,
       id = 'potato',
-      coords = c('X', 'Y')
+      coords = c('X', 'Y'),
+      timegroup = 'timegroup'
     ),
     'not present in input DT',
     fixed = FALSE
@@ -47,7 +48,8 @@ test_that('column names must exist in DT', {
     edge_nn(
       DT,
       id = 'ID',
-      coords = c('potatoX', 'potatoY')
+      coords = c('potatoX', 'potatoY'),
+      timegroup = 'timegroup'
     ),
     'not present in input DT',
     fixed = FALSE
@@ -59,7 +61,8 @@ test_that('column names must exist in DT', {
       DT,
       id = 'ID',
       coords = c('X', 'Y'),
-      splitBy = 'potato'
+      splitBy = 'potato',
+      timegroup = 'timegroup'
     ),
     'not present in input DT',
     fixed = FALSE
@@ -84,7 +87,8 @@ test_that('threshold correctly provided or error detected', {
   expect_silent(edge_nn(
     copyDT,
     id = 'ID',
-    coords = c('X', 'Y')
+    coords = c('X', 'Y'),
+    timegroup = 'timegroup'
   ))
 
   expect_error(edge_nn(DT, threshold = -10, id = 'ID'),
@@ -112,7 +116,8 @@ test_that('coords are correctly provided or error detected', {
     edge_nn(
       DT,
       id = 'ID',
-      coords = c('X', 'ID')
+      coords = c('X', 'ID'),
+      timegroup = 'timegroup'
     ),
     'coords must be numeric'
   )

--- a/tests/testthat/test-edge-nn.R
+++ b/tests/testthat/test-edge-nn.R
@@ -88,7 +88,7 @@ test_that('threshold correctly provided or error detected', {
     copyDT,
     id = 'ID',
     coords = c('X', 'Y'),
-    timegroup = 'timegroup'
+    timegroup = NULL
   ))
 
   expect_error(edge_nn(DT, threshold = -10, id = 'ID'),
@@ -117,7 +117,7 @@ test_that('coords are correctly provided or error detected', {
       DT,
       id = 'ID',
       coords = c('X', 'ID'),
-      timegroup = 'timegroup'
+      timegroup = NULL
     ),
     'coords must be numeric'
   )

--- a/tests/testthat/test-pts.R
+++ b/tests/testthat/test-pts.R
@@ -4,6 +4,9 @@ library(spatsoc)
 
 DT <- fread('../testdata/DT.csv')
 
+DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
+group_times(DT, datetime = 'datetime', threshold = '20 minutes')
+
 test_that('DT is required', {
   expect_error(group_pts(
     DT = NULL,
@@ -41,7 +44,8 @@ test_that('column names must exist in DT', {
       DT,
       threshold = 10,
       id = 'potato',
-      coords = c('X', 'Y')
+      coords = c('X', 'Y'),
+      timegroup = NULL
     ),
     'not present in input DT',
     fixed = FALSE
@@ -53,7 +57,8 @@ test_that('column names must exist in DT', {
       DT,
       threshold = 10,
       id = 'ID',
-      coords = c('potatoX', 'potatoY')
+      coords = c('potatoX', 'potatoY'),
+      timegroup = NULL
     ),
     'not present in input DT',
     fixed = FALSE
@@ -66,6 +71,7 @@ test_that('column names must exist in DT', {
       threshold = 10,
       id = 'ID',
       coords = c('X', 'Y'),
+      timegroup = NULL,
       splitBy = 'potato'
     ),
     'not present in input DT',
@@ -93,7 +99,8 @@ test_that('threshold correctly provided or error detected', {
     copyDT,
     threshold = 10,
     id = 'ID',
-    coords = c('X', 'Y')
+    coords = c('X', 'Y'),
+    timegroup = 'timegroup'
   ))
 
   expect_error(group_pts(DT, threshold = -10, id = 'ID'),
@@ -123,7 +130,8 @@ test_that('coords are correctly provided or error detected', {
       DT,
       threshold = 10,
       id = 'ID',
-      coords = c('X', 'ID')
+      coords = c('X', 'ID'),
+      timegroup = NULL
     ),
     'coords must be numeric'
   )
@@ -136,7 +144,8 @@ test_that('DT returned if timegroup, group fields not provided', {
                  copyDT,
                  threshold = 10,
                  id = 'ID',
-                 coords = c('X', 'Y')
+                 coords = c('X', 'Y'),
+                 timegroup = 'timegroup'
                )))
 
   # warns if > 1 ID row
@@ -201,7 +210,8 @@ test_that('group column succesfully detected', {
       copyDT,
       threshold = 10,
       id = 'ID',
-      coords = c('X', 'Y')
+      coords = c('X', 'Y'),
+      timegroup = 'timegroup'
     ),
     'group column will be overwritten'
   )


### PR DESCRIPTION
If someone mistakenly provides a large `DT` to (`group_pts`, `edge_nn` or `edge_dist`) without providing a `timegroup`, it'll compute a huge distance matrix and likely slow/crash their computer. 

To avoid this, remove the default NULL for `timegroup` arguments and require them to explicitly set it to NULL if they want to group/edge without a timegroup. 