### PR TITLE
fixes #34

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: spatsoc
 Title: Group Animal Relocation Data by Spatial and Temporal Relationship
-Version: 0.1.15
+Version: 0.1.16
 Authors@R: 
     c(person(given = "Alec L.",
              family = "Robitaille",

--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -1,4 +1,5 @@
 library(testthat)
+options("rgdal_show_exportToProj4_warnings"="none")
 library(spatsoc)
 
 test_check("spatsoc")

--- a/tests/testthat/test-group-lines.R
+++ b/tests/testthat/test-group-lines.R
@@ -4,7 +4,7 @@ library(spatsoc)
 
 DT <- fread('../testdata/DT.csv')
 
-utm <- '+init=epsg:32736'
+utm <- '+init=epsg:32736' # should be "EPSG:32736"
 
 DT[, datetime := as.POSIXct(datetime)]
 DT[, jul := data.table::yday(datetime)]
@@ -161,6 +161,7 @@ test_that('timegroup is correctly provided but is not required', {
 
 
 test_that('threshold is correctly provided, or error', {
+  options("rgdal_show_exportToProj4_warnings"="none")
   copyDT <- copy(DT)
   # to avoid block length warning
   suppressWarnings(

--- a/tests/testthat/test-group-lines.R
+++ b/tests/testthat/test-group-lines.R
@@ -161,7 +161,6 @@ test_that('timegroup is correctly provided but is not required', {
 
 
 test_that('threshold is correctly provided, or error', {
-  options("rgdal_show_exportToProj4_warnings"="none")
   copyDT <- copy(DT)
   # to avoid block length warning
   suppressWarnings(


### PR DESCRIPTION
The addition of an option to block **sp**/**rgdal** warnings of degraded Proj.4 string representations helps. The cause of the difference PROJ 7.2.1/8.0.0 is that WGS84 is a DATUM in 7.2.1, but a datum ENSEMBLE in 8.0.0 (there are multiple definitions - for your purposes probably not important which is used unless you are in an area with  many earthquakes or rapid tectonic shift. The next release of **rgdal** will not warn on this, but the released version was looking for DATUM, found ENSEMBLE, so warned that DATUM was missing.