### PR TITLE
Add keyword internal

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Suggests:
     asnipe,
     markdown
 SystemRequirements: GEOS (>= 3.2.0)
-RoxygenNote: 7.1.1
+RoxygenNote: 7.2.1
 VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
 BugReports: https://github.com/ropensci/spatsoc/issues

--- a/R/spatsoc.R
+++ b/R/spatsoc.R
@@ -23,4 +23,5 @@
 #' @docType package
 #' @name spatsoc
 #' @aliases spatsoc-package
+#' @keywords internal
 "_PACKAGE"

--- a/man/spatsoc.Rd
+++ b/man/spatsoc.Rd
@@ -47,3 +47,4 @@ Authors:
 }
 
 }
+\keyword{internal}


### PR DESCRIPTION
Note that I did not run `document()`. This PR + running `document()` should make this pkgdown error disappear:

```
Error in check_missing_topics(rows, pkg) : 
  All topics must be included in reference index
• Missing topics: spatsoc
```