### PR TITLE
Rm unnecessary lines

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,13 +1,3 @@
-destination: ../spatsoc.gitlab.io/public
-url: https://spatsoc.gitlab.io
-
-
-template:
-  params:
-    bootswatch: yeti
-    ganalytics: "UA-130501037-2"
-
-
 reference:
   - title: Temporal grouping
     desc: ~

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,13 +1,3 @@
-pandoc: 2.2.1
-pkgdown: 1.1.0
-pkgdown_sha: ~
-articles:
-  intro-spatsoc: intro-spatsoc.html
-  faq: faq.html
-  using-in-sna: using-in-sna.html
-  using-edge-and-dyad: using-edge-and-dyad.html
-
-
 destination: ../spatsoc.gitlab.io/public
 url: https://spatsoc.gitlab.io
 


### PR DESCRIPTION
@robitalec I think these lines came from a `_pkgdown.yml` inside the site (https://docs.ropensci.org/spatsoc/pkgdown.yml) but they should not be in the source configuration (admittedly a bit confusing :sweat_smile: ). We saw an error on https://ropensci.r-universe.dev/ui#builds that I was able to reproduce with `pkgdown::check_pkgdown()`. After merging this PR the build should be fixed.