### PR TITLE
Fix/replace igraph clusters with components

### DIFF
--- a/R/group_lines.R
+++ b/R/group_lines.R
@@ -174,7 +174,7 @@ group_lines <-
       }
       dimnames(inter) <- list(sfLines[[id]], sfLines[[id]])
       g <- igraph::graph_from_adjacency_matrix(inter)
-      ovr <- igraph::clusters(g)$membership
+      ovr <- igraph::components(g)$membership
       out <- data.table::data.table(names(ovr),
                                     unlist(ovr))
       data.table::setnames(out, c('ID', 'group'))
@@ -237,7 +237,7 @@ group_lines <-
         }
         dimnames(inter) <- list(lns[[id]], lns[[id]])
         g <- igraph::graph_from_adjacency_matrix(inter)
-        ovr <- igraph::clusters(g)$membership
+        ovr <- igraph::components(g)$membership
         ovrDT <- data.table::data.table(ID = names(ovr),
                                         group = unlist(ovr))
       } else {
@@ -291,7 +291,7 @@ group_lines <-
             }
             dimnames(inter) <- list(lns[[id]], lns[[id]])
             g <- igraph::graph_from_adjacency_matrix(inter)
-            ovr <- igraph::clusters(g)$membership
+            ovr <- igraph::components(g)$membership
             out <- data.table::data.table(names(ovr),
                                           unlist(ovr))
             data.table::setnames(out, c(..id, 'withinGroup'))

--- a/R/group_polys.R
+++ b/R/group_polys.R
@@ -156,7 +156,7 @@ group_polys <-
         inter <- sf::st_intersects(sfPolys, sfPolys, sparse = FALSE)
         dimnames(inter) <- list(sfPolys[[id]], sfPolys[[id]])
         g <- igraph::graph_from_adjacency_matrix(inter)
-        ovr <- igraph::clusters(g)$membership
+        ovr <- igraph::components(g)$membership
         out <- data.table::data.table(names(ovr),
                                       as.integer(unlist(ovr)))
         data.table::setnames(out, c(id, 'group'))
@@ -244,7 +244,7 @@ group_polys <-
               inter <- sf::st_intersects(sfPolys, sfPolys, sparse = FALSE)
               dimnames(inter) <- list(sfPolys[[..id]], sfPolys[[..id]])
               g <- igraph::graph_from_adjacency_matrix(inter)
-              ovr <- igraph::clusters(g)$membership
+              ovr <- igraph::components(g)$membership
               out <- data.table::data.table(names(ovr),
                                             as.integer(unlist(ovr)))
               data.table::setnames(out, c(id, 'withinGroup'))

--- a/R/group_pts.R
+++ b/R/group_pts.R
@@ -182,7 +182,7 @@ group_pts <- function(DT = NULL,
       method = 'euclidean'))
     graphAdj <-
       igraph::graph_from_adjacency_matrix(distMatrix <= threshold)
-    igraph::clusters(graphAdj)$membership
+    igraph::components(graphAdj)$membership
   },
   by = c(splitBy, timegroup), .SDcols = c(coords, id)]
   DT[, group := .GRP,


### PR DESCRIPTION
From tests:

```r
Warning (test-gbi.R:14:1): (code run outside of `test_that()`)
`clusters()` was deprecated in igraph 2.0.0.
ℹ Please use `components()` instead.
Backtrace:
    ▆
 1. ├─spatsoc::group_pts(...) at test-gbi.R:14:1
 2. │ ├─...[] at spatsoc/R/group_pts.R:177:3
 3. │ └─data.table::`[.data.table`(...) at spatsoc/R/group_pts.R:177:3
 4. └─igraph::clusters(graphAdj) at spatsoc/R/group_pts.R:185:5
 ```