### PR TITLE
Fix/bracket typo longlat direction_step

### DIFF
--- a/R/direction_step.R
+++ b/R/direction_step.R
@@ -121,9 +121,8 @@ direction_step <- function(
   if (sf::st_is_longlat(projection)) {
     DT[, direction := c(
       lwgeom::st_geod_azimuth(
-        sf::st_as_sf(.SD, coords = coords, crs = projection))
-      ),
-      units::set_units(NA, 'rad'),
+        sf::st_as_sf(.SD, coords = coords, crs = projection)),
+      units::set_units(NA, 'rad')),
       by = c(id, splitBy)]
   } else if (!sf::st_is_longlat(projection)) {
     DT[, direction := c(

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -113,3 +113,24 @@ test_that('splitBy returns expected', {
 
   )
 })
+
+
+DT_A <- data.table(
+  x = c(-5, -5, 0, 14, 10, 0),
+  y = c(5, 3, 1, 1, 11, 11),
+  id =  'A'
+)[, timegroup := seq.int(.N)]
+
+# Related to: PR 92
+test_that('longlat NA radian returned', {
+  expect_equal(
+    direction_step(DT_A, id = 'id', coords = c('x', 'y'),
+                   projection = 4326)[]$direction |> class(),
+    'units'
+  )
+  expect_gte(
+    sum(is.na(direction_step(DT_A, id = 'id', coords = c('x', 'y'),
+                   projection = 4326)[]$direction)),
+    1
+  )
+})


### PR DESCRIPTION
Bracket misplaced returning by/keyby error. Typo was accidentally setting keyby instead of returning an NA radian for the last observation for each by. 


Added test, errors returned before fix:


```r
# Related to: PR 92
test_that('longlat NA radian returned', {
  expect_equal(
    direction_step(DT_A, id = 'id', coords = c('x', 'y'),
                   projection = 4326)[]$direction |> class(),
    'units'
  )
  expect_gte(
    sum(is.na(direction_step(DT_A, id = 'id', coords = c('x', 'y'),
                   projection = 4326)[]$direction)),
    1
  )
})
── Error: longlat NA radian returned ───────────────────────────────────────────
Error in ``[.data.table`(DT, , `:=`(direction, c(lwgeom::st_geod_azimuth(sf::st_as_sf(.SD, 
    coords = coords, crs = projection)))), units::set_units(NA, 
    "rad"), by = c(id, splitBy))`: When by and keyby are both provided, keyby must be TRUE or FALSE
Backtrace:
    ▆
 1. ├─testthat::expect_equal(...)
 2. │ └─testthat::quasi_label(enquo(object), label, arg = "object")
 3. │   └─rlang::eval_bare(expr, quo_get_env(quo))
 4. └─global direction_step(DT_A, id = "id", coords = c("x", "y"), projection = 4326)
 5.   ├─...[] at spatsoc/R/direction_step.R:122:5
 6.   └─data.table:::`[.data.table`(...) at spatsoc/R/direction_step.R:122:5
 7.     └─data.table:::stopf("When by and keyby are both provided, keyby must be TRUE or FALSE")
 8.       └─data.table:::raise_condition(...)

Error:
! Test failed
Backtrace:
    ▆
 1. ├─testthat::test_that(...)
 2. │ └─withr (local) `<fn>`()
 3. └─reporter$stop_if_needed()
 4.   └─rlang::abort("Test failed", call = NULL)
 ```
