### PR TITLE
Fix/test expected direction of steps

### DIFF
--- a/R/direction_step.R
+++ b/R/direction_step.R
@@ -71,6 +71,17 @@
 #'   coords = c('X', 'Y'),
 #'   projection = 32736
 #' )
+#'
+#' # Example result for East, North, West, South steps
+#' example <- data.table(
+#'   X = c(0, 5, 5, 0, 0),
+#'   Y = c(0, 0, 5, 5, 0),
+#'   step = c('E', 'N', 'W', 'S', NA),
+#'   ID = 'A'
+#' )
+#'
+#' direction_step(example, 'ID', c('X', 'Y'), projection = 4326)
+#' example[, .(direction, units::set_units(direction, 'degree'))]
 direction_step <- function(
     DT = NULL,
     id = NULL,

--- a/man/direction_step.Rd
+++ b/man/direction_step.Rd
@@ -94,6 +94,17 @@ direction_step(
   coords = c('X', 'Y'),
   projection = 32736
 )
+
+# Example result for East, North, West, South steps
+example <- data.table(
+  X = c(0, 5, 5, 0, 0),
+  Y = c(0, 0, 5, 5, 0),
+  step = c('E', 'N', 'W', 'S', NA),
+  ID = 'A'
+)
+
+direction_step(example, 'ID', c('X', 'Y'), projection = 4326)
+example[, .(direction, units::set_units(direction, 'degree'))]
 }
 \seealso{
 \code{\link[amt:steps]{amt::direction_abs()}}, \code{\link[geosphere:bearing]{geosphere::bearing()}}

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -144,16 +144,3 @@ DT_B <- data.table(
   ID = 'B'
 )
 direction_step(DT_B, id, coords, projection = 4326)
-DT_B[, deg := units::set_units(direction, 'degree')]
-
-plot(DT_B$X, DT_B$Y)
-text(DT_B$X + c(0.3, -0.3, -0.3, 0.3, NA), DT_B$Y,
-     paste0('t ', DT_B$timegroup, ', dir ', round(DT_B$direction, 2)))
-
-pts <- st_sfc(st_point(c(0, 0)),
-       st_point(c(5, 0)),
-       st_point(c(5, 5)),
-       st_point(c(0, 5)),
-       st_point(c(0, 0)),
-       crs = 4326)
-st_geod_azimuth(pts)

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -116,21 +116,21 @@ test_that('splitBy returns expected', {
 
 
 DT_A <- data.table(
-  x = c(-5, -5, 0, 14, 10, 0),
-  y = c(5, 3, 1, 1, 11, 11),
-  id =  'A'
+  X = c(-5, -5, 0, 14, 10, 0),
+  Y = c(5, 3, 1, 1, 11, 11),
+  ID =  'A'
 )[, timegroup := seq.int(.N)]
 
 # Related to: PR 92
 test_that('longlat NA radian returned', {
   expect_equal(
-    direction_step(DT_A, id = 'id', coords = c('x', 'y'),
-                   projection = 4326)[]$direction |> class(),
+    class(direction_step(DT_A, id = id, coords = coords,
+                         projection = 4326)[]$direction),
     'units'
   )
   expect_gte(
-    sum(is.na(direction_step(DT_A, id = 'id', coords = c('x', 'y'),
-                   projection = 4326)[]$direction)),
+    sum(is.na(direction_step(DT_A, id = id, coords = coords,
+                   projection = 4326)$direction)),
     1
   )
 })

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -143,3 +143,5 @@ DT_B <- data.table(
   timegroup = seq.int(5),
   ID = 'B'
 )
+direction_step(DT_B, id, coords, projection = 4326)
+DT_B[, deg := units::set_units(direction, 'degree')]

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -145,3 +145,7 @@ DT_B <- data.table(
 )
 direction_step(DT_B, id, coords, projection = 4326)
 DT_B[, deg := units::set_units(direction, 'degree')]
+
+plot(DT_B$X, DT_B$Y)
+text(DT_B$X + c(0.3, -0.3, -0.3, 0.3, NA), DT_B$Y,
+     paste0('t ', DT_B$timegroup, ', dir ', round(DT_B$direction, 2)))

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -149,3 +149,11 @@ DT_B[, deg := units::set_units(direction, 'degree')]
 plot(DT_B$X, DT_B$Y)
 text(DT_B$X + c(0.3, -0.3, -0.3, 0.3, NA), DT_B$Y,
      paste0('t ', DT_B$timegroup, ', dir ', round(DT_B$direction, 2)))
+
+pts <- st_sfc(st_point(c(0, 0)),
+       st_point(c(5, 0)),
+       st_point(c(5, 5)),
+       st_point(c(0, 5)),
+       st_point(c(0, 0)),
+       crs = 4326)
+st_geod_azimuth(pts)

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -144,3 +144,31 @@ DT_B <- data.table(
   ID = 'B'
 )
 direction_step(DT_B, id, coords, projection = 4326)
+
+test_that('East North West South steps', {
+  tolerance <- 0.01
+
+  expect_equal(
+    DT_B[step == 'E', direction],
+    as_units(pi / 2, 'rad'),
+    tolerance = tolerance
+  )
+
+  expect_equal(
+    DT_B[step == 'N', direction],
+    as_units(0),
+    tolerance = tolerance
+  )
+
+  expect_equal(
+    DT_B[step == 'W', direction],
+    as_units(- pi / 2),
+    tolerance = tolerance
+  )
+
+  expect_equal(
+    DT_B[step == 'S', direction],
+    as_units(pi),
+    tolerance = tolerance
+  )
+})

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -134,3 +134,12 @@ test_that('longlat NA radian returned', {
     1
   )
 })
+
+
+DT_B <- data.table(
+  X = c(0, 5, 5, 0, 0),
+  Y = c(0, 0, 5, 5, 0),
+  step = c('E', 'N', 'W', 'S', NA),
+  timegroup = seq.int(5),
+  ID = 'B'
+)

--- a/tests/testthat/test-direction-step.R
+++ b/tests/testthat/test-direction-step.R
@@ -2,6 +2,7 @@
 context('test direction_step')
 
 library(spatsoc)
+library(units)
 
 DT <- fread('../testdata/DT.csv')
 


### PR DESCRIPTION
Adds tests for simple steps in cardinal directions and adds example to illustrate how underlying {lwgeom} function returns azimuths. 