### PR TITLE
Fix/improve output name edge delay

### DIFF
--- a/R/edge_delay.R
+++ b/R/edge_delay.R
@@ -115,8 +115,8 @@ edge_delay <- function(
     id = NULL,
     direction = 'direction') {
   # due to NSE notes in R CMD check
-  . <- timegroup <- fusionID <- min_timegroup <- max_timegroup <-
-    delay_timegroup <- ID1  <- ID2 <- dir_corr_delay <- NULL
+  . <- timegroup <- fusionID <- timegroup_min <- timegroup_max <-
+    timegroup_delay <- ID1  <- ID2 <- dir_corr_delay <- NULL
 
   if (is.null(DT)) {
     stop('input DT required')
@@ -178,24 +178,24 @@ edge_delay <- function(
                    data.table::first(.SD),
                    by = .(fusionID, timegroup)]
 
-  forward[, min_timegroup :=
+  forward[, timegroup_min :=
             data.table::fifelse(timegroup - window < min(timegroup),
                                 min(timegroup),
                                 timegroup - window),
           by = fusionID,
           env = list(window = window)]
 
-  forward[, max_timegroup :=
+  forward[, timegroup_max :=
             data.table::fifelse(timegroup + window > max(timegroup),
                                 max(timegroup),
                                 timegroup + window),
           by = fusionID,
           env = list(window = window)]
 
-  forward[, delay_timegroup := {
+  forward[, timegroup_delay := {
     focal_direction <- DT[timegroup == .BY$timegroup &
                             id == ID1, direction]
-    DT[between(timegroup, min_timegroup, max_timegroup) & id == ID2,
+    DT[between(timegroup, timegroup_min, timegroup_max) & id == ID2,
        timegroup[which.min(diff_rad(focal_direction, direction))]]
   },
   by = c('timegroup',  'dyadID'),
@@ -204,7 +204,7 @@ edge_delay <- function(
   forward[, direction_delay := timegroup_delay - timegroup]
 
   data.table::set(forward,
-                  j = c('min_timegroup', 'max_timegroup','delay_timegroup'),
+                  j = c('timegroup_min', 'timegroup_max','timegroup_delay'),
                   value = NULL)
 
   # "Reverse": replicate forward but reverse direction ID1 <- ID2

--- a/R/edge_delay.R
+++ b/R/edge_delay.R
@@ -117,7 +117,7 @@ edge_delay <- function(
     direction = 'direction') {
   # due to NSE notes in R CMD check
   . <- timegroup <- fusionID <- timegroup_min <- timegroup_max <-
-    timegroup_delay <- ID1  <- ID2 <- dir_corr_delay <- NULL
+    timegroup_delay <- ID1  <- ID2 <- direction_delay <- direction_diff <- NULL
 
   if (is.null(DT)) {
     stop('input DT required')

--- a/R/edge_delay.R
+++ b/R/edge_delay.R
@@ -108,7 +108,7 @@
 #'   id = 'ID'
 #' )
 #'
-#' delay[, mean(dir_corr_delay, na.rm = TRUE), by = .(ID1, ID2)][V1 > 0]
+#' delay[, mean(direction_delay, na.rm = TRUE), by = .(ID1, ID2)][V1 > 0]
 edge_delay <- function(
     edges,
     DT,

--- a/R/edge_delay.R
+++ b/R/edge_delay.R
@@ -193,11 +193,14 @@ edge_delay <- function(
           by = fusionID,
           env = list(window = window)]
 
-  forward[, timegroup_delay := {
+  forward[, c('timegroup_delay', 'direction_diff') := {
     focal_direction <- DT[timegroup == .BY$timegroup &
                             id == ID1, direction]
     DT[between(timegroup, timegroup_min, timegroup_max) & id == ID2,
        timegroup[which.min(diff_rad(focal_direction, direction))]]
+    sub <- DT[between(timegroup, timegroup_min, timegroup_max) & id == ID2,
+              .(timegroup, diff = diff_rad(focal_direction, direction))]
+    sub[which.min(diff)]
   },
   by = c('timegroup',  'dyadID'),
   env = list(id = id, direction = direction)]

--- a/R/edge_delay.R
+++ b/R/edge_delay.R
@@ -196,8 +196,6 @@ edge_delay <- function(
   forward[, c('timegroup_delay', 'direction_diff') := {
     focal_direction <- DT[timegroup == .BY$timegroup &
                             id == ID1, direction]
-    DT[between(timegroup, timegroup_min, timegroup_max) & id == ID2,
-       timegroup[which.min(diff_rad(focal_direction, direction))]]
     sub <- DT[between(timegroup, timegroup_min, timegroup_max) & id == ID2,
               .(timegroup, diff = diff_rad(focal_direction, direction))]
     sub[which.min(diff)]

--- a/R/edge_delay.R
+++ b/R/edge_delay.R
@@ -31,15 +31,16 @@
 #'   \code{group_times}, eg. \code{window = 4} corresponds to the 4 timegroups
 #'   before and after the focal observation
 #'
-#' @return \code{edge_delay} returns the input \code{edges} appended with
-#'   timegroups) at which ID1's direction of movement is most similar to
-#'   ID2's direction of movement, within the temporal window defined. For
-#'   example, if focal individual 'A' moves in a 45 degree direction at time 2
-#'   and individual 'B' moves in a most similar direction within the window
-#'   at time 5, the directional correlation delay between A and B is 3. Positive
-#'   values of directional correlation delay indicate a directed leadership
-#'   edge from ID1 to ID2.
+#' @return \code{edge_delay} returns the input \code{edges} appended with a
 #'   'direction_delay' column indicating the temporal delay (in units of
+#'   timegroups) at which ID1's direction of movement is most similar to ID2's
+#'   direction of movement, within the temporal window defined, and a
+#'   'direction_diff' column indicating the absolute difference in direction.
+#'   For example, if focal individual 'A' moves in a 45 degree direction at time
+#'   2 and individual 'B' moves in a most similar direction within the window at
+#'   time 5, the directional correlation delay between A and B is 3. Positive
+#'   values of directional correlation delay indicate a directed leadership edge
+#'   from ID1 to ID2.
 #'
 #' @export
 #'

--- a/R/edge_delay.R
+++ b/R/edge_delay.R
@@ -32,7 +32,6 @@
 #'   before and after the focal observation
 #'
 #' @return \code{edge_delay} returns the input \code{edges} appended with
-#'   a 'dir_corr_delay' column indicating the temporal delay (in units of
 #'   timegroups) at which ID1's direction of movement is most similar to
 #'   ID2's direction of movement, within the temporal window defined. For
 #'   example, if focal individual 'A' moves in a 45 degree direction at time 2
@@ -40,6 +39,7 @@
 #'   at time 5, the directional correlation delay between A and B is 3. Positive
 #'   values of directional correlation delay indicate a directed leadership
 #'   edge from ID1 to ID2.
+#'   'direction_delay' column indicating the temporal delay (in units of
 #'
 #' @export
 #'
@@ -201,7 +201,7 @@ edge_delay <- function(
   by = c('timegroup',  'dyadID'),
   env = list(id = id, direction = direction)]
 
-  forward[, dir_corr_delay := delay_timegroup - timegroup]
+  forward[, direction_delay := timegroup_delay - timegroup]
 
   data.table::set(forward,
                   j = c('min_timegroup', 'max_timegroup','delay_timegroup'),
@@ -210,7 +210,7 @@ edge_delay <- function(
   # "Reverse": replicate forward but reverse direction ID1 <- ID2
   reverse <- data.table::copy(forward)
   setnames(reverse, c('ID1', 'ID2'), c('ID2', 'ID1'))
-  reverse[, dir_corr_delay := - dir_corr_delay]
+  reverse[, direction_delay := - direction_delay]
 
   out <- data.table::rbindlist(list(
     forward,

--- a/man/edge_delay.Rd
+++ b/man/edge_delay.Rd
@@ -24,15 +24,16 @@ before and after the focal observation}
 "direction"}
 }
 \value{
-\code{edge_delay} returns the input \code{edges} appended with
-a 'dir_corr_delay' column indicating the temporal delay (in units of
-timegroups) at which ID1's direction of movement is most similar to
-ID2's direction of movement, within the temporal window defined. For
-example, if focal individual 'A' moves in a 45 degree direction at time 2
-and individual 'B' moves in a most similar direction within the window
-at time 5, the directional correlation delay between A and B is 3. Positive
-values of directional correlation delay indicate a directed leadership
-edge from ID1 to ID2.
+\code{edge_delay} returns the input \code{edges} appended with a
+'direction_delay' column indicating the temporal delay (in units of
+timegroups) at which ID1's direction of movement is most similar to ID2's
+direction of movement, within the temporal window defined, and a
+'direction_diff' column indicating the absolute difference in direction.
+For example, if focal individual 'A' moves in a 45 degree direction at time
+2 and individual 'B' moves in a most similar direction within the window at
+time 5, the directional correlation delay between A and B is 3. Positive
+values of directional correlation delay indicate a directed leadership edge
+from ID1 to ID2.
 }
 \description{
 \code{edge_delay} returns edge lists defined by the directional correlation
@@ -111,7 +112,7 @@ delay <- edge_delay(
   id = 'ID'
 )
 
-delay[, mean(dir_corr_delay, na.rm = TRUE), by = .(ID1, ID2)][V1 > 0]
+delay[, mean(direction_delay, na.rm = TRUE), by = .(ID1, ID2)][V1 > 0]
 }
 \references{
 The directional correlation delay is defined in Nagy et al. 2010

--- a/tests/testthat/test-edge-delay.R
+++ b/tests/testthat/test-edge-delay.R
@@ -92,7 +92,7 @@ test_that('no rows are added to the result edges', {
 test_that('column added to the result DT', {
   copyEdges <- copy(edges)
 
-  expected_cols <- c(colnames(copyEdges), 'dir_corr_delay')
+  expected_cols <- c(colnames(copyEdges), 'direction_delay')
 
   expect_setequal(expected_cols,
                   colnames(edge_delay(edges, DT, id = id, window = window)))
@@ -102,7 +102,7 @@ test_that('column added to the result DT', {
 })
 
 test_that('column added to the result DT is integer', {
-  expect_type(edge_delay(edges, DT, id = id, window = window)$dir_corr_delay, 'integer')
+  expect_type(edge_delay(edges, DT, id = id, window = window)$direction_delay, 'integer')
 })
 
 test_that('returns a data.table', {
@@ -170,13 +170,13 @@ test_that('expected results are returned', {
   expect_lte(nrow(delay), nrow(edges_expect))
   expect_lte(nrow(DT_expect), nrow(delay))
 
-  mean_delays <- delay[, mean(dir_corr_delay, na.rm = TRUE), by = ID1]
+  mean_delays <- delay[, mean(direction_delay, na.rm = TRUE), by = ID1]
 
   expect_equal(mean_delays[V1 == min(V1), ID1], LETTERS[N_id])
   expect_equal(mean_delays[V1 == median(V1), ID1], LETTERS[ceiling(N_id / 2)])
   expect_equal(mean_delays[V1 == max(V1), ID1], LETTERS[1])
 
-  mean_delays_wrt_A <- delay[ID1 == 'A', mean(dir_corr_delay, na.rm = TRUE),
+  mean_delays_wrt_A <- delay[ID1 == 'A', mean(direction_delay, na.rm = TRUE),
                              by = ID2]
   expect_equal(mean_delays_wrt_A[V1 == max(V1), ID2], LETTERS[N_id])
 })

--- a/tests/testthat/test-edge-delay.R
+++ b/tests/testthat/test-edge-delay.R
@@ -109,7 +109,7 @@ test_that('returns a data.table', {
   expect_s3_class(edge_delay(edges, DT, id = id, window = window), 'data.table')
 })
 
-test_that('direction colname can different than default', {
+test_that('direction colname can be different than default', {
   copyDT <- copy(clean_DT)
   setnames(copyDT, 'direction', 'potato')
   expect_s3_class(edge_delay(edges, copyDT, id = id, window = window,

--- a/tests/testthat/test-edge-delay.R
+++ b/tests/testthat/test-edge-delay.R
@@ -92,7 +92,7 @@ test_that('no rows are added to the result edges', {
 test_that('column added to the result DT', {
   copyEdges <- copy(edges)
 
-  expected_cols <- c(colnames(copyEdges), 'direction_delay')
+  expected_cols <- c(colnames(copyEdges), 'direction_delay', 'direction_diff')
 
   expect_setequal(expected_cols,
                   colnames(edge_delay(edges, DT, id = id, window = window)))


### PR DESCRIPTION
Fixing output name from edge_delay for consistency with other functions, before using output downstream in leader_edge_delay. Adds direction_diff to output as difference in direction at temporal delay (direction_delay)

dir_corr_delay -> direction_delay
(not present) -> direction_diff

