### PR TITLE
Fix/centroids should return NAs where NA in dyadID or fusionID

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,9 +1,16 @@
+# Development version
+
+Fixes:
+
+* Fix `centroid_dyad` and `centroid_fusion` return NA for centroids 
+when dyadID / fusionID are NA ([PR 114](https://github.com/ropensci/spatsoc/pull/114))
+
+
 # spatsoc 0.2.10
 
 New experimental function:
 
 * `edge_alignment` function for calculating directional alignment ([PR 111](https://github.com/ropensci/spatsoc/pull/111))
-
 
 # spatsoc 0.2.9
 

--- a/R/centroid_dyad.R
+++ b/R/centroid_dyad.R
@@ -195,5 +195,7 @@ centroid_dyad <- function(
   data.table::set(m, j = c(id1_coords, id2_coords), value = NULL)
   data.table::setcolorder(m, colnames(edges))
 
+  m[is.na(dyadID), (c(out_xcol, out_ycol)) := NA]
+
   return(m[])
 }

--- a/R/centroid_dyad.R
+++ b/R/centroid_dyad.R
@@ -96,6 +96,8 @@ centroid_dyad <- function(
     coords = NULL,
     timegroup = 'timegroup',
     na.rm = FALSE) {
+  # Due to NSE notes in R CMD check
+  dyadID <- NULL
 
   if (is.null(DT)) {
     stop('input DT required')

--- a/R/centroid_fusion.R
+++ b/R/centroid_fusion.R
@@ -199,5 +199,7 @@ centroid_fusion <- function(
   data.table::set(m, j = c(id1_coords, id2_coords), value = NULL)
   data.table::setcolorder(m, colnames(edges))
 
+  m[is.na(fusionID), (c(out_xcol, out_ycol)) := NA]
+
   return(m[])
 }

--- a/R/centroid_fusion.R
+++ b/R/centroid_fusion.R
@@ -101,6 +101,8 @@ centroid_fusion <- function(
     coords = NULL,
     timegroup = 'timegroup',
     na.rm = FALSE) {
+  # Due to NSE notes in R CMD check
+  fusionID <- NULL
 
   if (is.null(DT)) {
     stop('input DT required')

--- a/tests/testthat/test-centroid-dyad.R
+++ b/tests/testthat/test-centroid-dyad.R
@@ -143,3 +143,29 @@ test_that('results are expected', {
   )
 })
 
+
+test_that('NAs in dyadID result in NAs for centroid', {
+  # Set fillNA = TRUE
+  edges <- edge_dist(DT, threshold = threshold, id = id, coords = coords,
+                     timegroup = timegroup, returnDist = TRUE,
+                     fillNA = TRUE)
+  dyad_id(edges, id1 = 'ID1', id2 = 'ID2')
+
+  # Set na.rm = TRUE
+  centroids <- centroid_dyad(edges, DT, id, coords, na.rm = TRUE)
+  expect_true(
+    centroids[is.na(dyadID), all(is.na(centroid_X))]
+  )
+  expect_true(
+    centroids[is.na(dyadID), all(is.na(centroid_Y))]
+  )
+
+  # Set na.rm = FALSE
+  centroids <- centroid_dyad(edges, DT, id, coords, na.rm = FALSE)
+  expect_true(
+    centroids[is.na(dyadID), all(is.na(centroid_X))]
+  )
+  expect_true(
+    centroids[is.na(dyadID), all(is.na(centroid_Y))]
+  )
+})

--- a/tests/testthat/test-centroid-fusion.R
+++ b/tests/testthat/test-centroid-fusion.R
@@ -158,3 +158,31 @@ test_that('results are expected', {
   )
 })
 
+
+
+test_that('NAs in fusionID result in NAs for centroid', {
+  # Set fillNA = TRUE
+  edges <- edge_dist(DT, threshold = threshold, id = id, coords = coords,
+                     timegroup = timegroup, returnDist = TRUE,
+                     fillNA = TRUE)
+  dyad_id(edges, id1 = 'ID1', id2 = 'ID2')
+  fusion_id(edges, threshold = threshold)
+
+  # Set na.rm = TRUE
+  centroids <- centroid_fusion(edges, DT, id, coords, na.rm = TRUE)
+  expect_true(
+    centroids[is.na(fusionID), all(is.na(centroid_X))]
+  )
+  expect_true(
+    centroids[is.na(fusionID), all(is.na(centroid_Y))]
+  )
+
+  # Set na.rm = FALSE
+  centroids <- centroid_fusion(edges, DT, id, coords, na.rm = FALSE)
+  expect_true(
+    centroids[is.na(fusionID), all(is.na(centroid_X))]
+  )
+  expect_true(
+    centroids[is.na(fusionID), all(is.na(centroid_Y))]
+  )
+})


### PR DESCRIPTION
Bug: 

```r
       timegroup    ID1    ID2 distance dyadID fusionID centroid_X centroid_Y
           <int> <char> <char>    <num> <char>    <int>      <num>      <num>
    1:         1      A   <NA>       NA   <NA>       NA   715851.4    5505340
    2:         1      B      G 5.782904    B-G        1   699637.9    5509637
    3:         1      C   <NA>       NA   <NA>       NA   710205.4    5505888
    4:         1      D   <NA>       NA   <NA>       NA   700875.0    5490954
    5:         1      E   <NA>       NA   <NA>       NA   701671.9    5504286
```