### PR TITLE
Fix/speed up calc centroid

### DIFF
--- a/R/internal.R
+++ b/R/internal.R
@@ -190,8 +190,8 @@ assert_units_match <- function(x, y, n = 1) {
 #'    by = ID]
 #' DT[, centroid := sf::st_sfc(centroid, recompute_bbox = TRUE)]
 #' plot(DT$centroid)
-calc_centroid <- function(geometry, x, y, crs, use_s2 = TRUE) {
-  if (isTRUE(use_s2)) {
+calc_centroid <- function(geometry, x, y, crs, use_mean = FALSE) {
+  if (isFALSE(use_mean)) {
     if (!missing(geometry) && missing(x) && missing(y)) {
       if (identical(length(geometry), 1L)) {
         return(sf::st_as_sf(geometry))

--- a/tests/testthat/test-calc-centroid.R
+++ b/tests/testthat/test-calc-centroid.R
@@ -74,28 +74,28 @@ test_that('calc_centroid equals st_centroid for mean and length 1 inputs', {
   i_seq <- DT[, sample(.I, 100)]
 
   expect_equal(
-    setnames(DT[i_seq, calc_centroid(x = X, y = Y, crs = crs, use_s2 = FALSE)], new = new_nms),
+    setnames(DT[i_seq, calc_centroid(x = X, y = Y, crs = crs, use_mean = TRUE)], new = new_nms),
     data.frame(st_coordinates(
       st_centroid(st_combine(st_as_sf(DT[i_seq, .(X, Y)], coords = seq.int(2), crs = crs)))
     ))
   )
 
   expect_equal(
-    setnames(DT[i, calc_centroid(x = X, y = Y, crs = crs, use_s2 = FALSE)], new = new_nms),
+    setnames(DT[i, calc_centroid(x = X, y = Y, crs = crs, use_mean = TRUE)], new = new_nms),
     data.frame(st_coordinates(
       st_centroid(st_combine(st_as_sf(DT[i, .(X, Y)], coords = seq.int(2), crs = crs)))
     ))
   )
 
   expect_equal(
-    setnames(DT[i_seq, calc_centroid(x = X, y = Y, crs = NA_crs_, use_s2 = FALSE)], new = new_nms),
+    setnames(DT[i_seq, calc_centroid(x = X, y = Y, crs = NA_crs_, use_mean = TRUE)], new = new_nms),
     data.frame(st_coordinates(
       st_centroid(st_combine(st_as_sf(DT[i_seq, .(X, Y)], coords = seq.int(2), crs = NA_crs_)))
     ))
   )
 
   expect_equal(
-    setnames(DT[i, calc_centroid(x = X, y = Y, crs = crs, use_s2 = FALSE)], , new = new_nms),
+    setnames(DT[i, calc_centroid(x = X, y = Y, crs = crs, use_mean = TRUE)], , new = new_nms),
     data.frame(st_coordinates(
       st_centroid(st_combine(st_as_sf(DT[i, .(X, Y)], coords = seq.int(2), crs = NA_crs_)))
     ))


### PR DESCRIPTION
Speeds up internal `calc_centroid` by adding:
- [X] add a check for if length == 1, quickly return xy/geo
- [X] add a "use_mean" argument to bypass `st_centroid` to reduce overhead and replace with a mean calculation for CRS that are not lonlat

Ref: [geos::algorithm::Centroid Class Reference](https://libgeos.org/doxygen/classgeos_1_1algorithm_1_1Centroid.html) ("Dimension = 0 - Compute the average coordinate over all points.")
