### PR TITLE
Fix/reduce example runtimes again

### DIFF
--- a/R/centroid_dyad.R
+++ b/R/centroid_dyad.R
@@ -55,13 +55,14 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-#'
+#' \dontshow{
 #' # (Subset example data to reduce runtime on CRAN)
-#' DT <- DT[year(datetime) == 2016]
-#'
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 #'

--- a/R/centroid_fusion.R
+++ b/R/centroid_fusion.R
@@ -56,13 +56,14 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-#'
+#' \dontshow{
 #' # (Subset example data to reduce runtime on CRAN)
-#' DT <- DT[year(datetime) == 2016]
-#'
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 #'

--- a/R/centroid_group.R
+++ b/R/centroid_group.R
@@ -90,6 +90,9 @@
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 #'
+#' # (Subset example data to reduce runtime on CRAN)
+#' DT <- DT[year(datetime) == 2016]
+#'
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 #'

--- a/R/centroid_group.R
+++ b/R/centroid_group.R
@@ -86,13 +86,14 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-#'
+#' \dontshow{
 #' # (Subset example data to reduce runtime on CRAN)
-#' DT <- DT[year(datetime) == 2016]
-#'
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 #'

--- a/R/direction_to_centroid.R
+++ b/R/direction_to_centroid.R
@@ -51,13 +51,17 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 #'
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
-#'
+#' \dontshow{
+#' # (Subset example data to reduce runtime on CRAN)
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Temporal grouping
 #' group_times(DT, datetime = 'datetime', threshold = '20 minutes')
 #'

--- a/R/direction_to_leader.R
+++ b/R/direction_to_leader.R
@@ -55,13 +55,14 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-#'
+#' \dontshow{
 #' # (Subset example data to reduce runtime on CRAN)
-#' DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
-#'
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 #'

--- a/R/distance_to_centroid.R
+++ b/R/distance_to_centroid.R
@@ -96,7 +96,7 @@
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 #'
 #' # (Subset example data to reduce runtime on CRAN)
-#' DT <- DT[year(datetime) == 2016]
+#' DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
 #'
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]

--- a/R/distance_to_centroid.R
+++ b/R/distance_to_centroid.R
@@ -91,13 +91,14 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-#'
+#' \dontshow{
 #' # (Subset example data to reduce runtime on CRAN)
-#' DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
-#'
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 #'

--- a/R/distance_to_leader.R
+++ b/R/distance_to_leader.R
@@ -53,16 +53,17 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 #'
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
-#'
+#' \dontshow{
 #' # (Subset example data to reduce runtime on CRAN)
-#' DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
-#'
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Temporal grouping
 #' group_times(DT, datetime = 'datetime', threshold = '20 minutes')
 #'

--- a/R/leader_direction_group.R
+++ b/R/leader_direction_group.R
@@ -67,16 +67,17 @@
 #' # Load data.table
 #' library(data.table)
 #' \dontshow{data.table::setDTthreads(1)}
-#'
 #' # Read example data
 #' DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 #'
-#' # (Subset example data to reduce example run time)
-#' DT <- DT[year(datetime) == 2016]
-#'
 #' # Cast the character column to POSIXct
 #' DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
-#'
+#' \dontshow{
+#' # (Subset example data to reduce runtime on CRAN)
+#' if (isFALSE(rlang::is_interactive())) {
+#'   DT <- DT[as.Date(datetime) == '2017-01-17']
+#' }
+#' }
 #' # Temporal grouping
 #' group_times(DT, datetime = 'datetime', threshold = '20 minutes')
 #'

--- a/man/centroid_dyad.Rd
+++ b/man/centroid_dyad.Rd
@@ -118,13 +118,14 @@ Note: if the input is length 1, the input is returned.
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-
+\dontshow{
 # (Subset example data to reduce runtime on CRAN)
-DT <- DT[year(datetime) == 2016]
-
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 

--- a/man/centroid_fusion.Rd
+++ b/man/centroid_fusion.Rd
@@ -121,13 +121,14 @@ Note: if the input is length 1, the input is returned.
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-
+\dontshow{
 # (Subset example data to reduce runtime on CRAN)
-DT <- DT[year(datetime) == 2016]
-
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 

--- a/man/centroid_group.Rd
+++ b/man/centroid_group.Rd
@@ -110,13 +110,14 @@ Note: if the input is length 1, the input is returned.
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-
+\dontshow{
 # (Subset example data to reduce runtime on CRAN)
-DT <- DT[year(datetime) == 2016]
-
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 

--- a/man/centroid_group.Rd
+++ b/man/centroid_group.Rd
@@ -114,6 +114,9 @@ library(data.table)
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 
+# (Subset example data to reduce runtime on CRAN)
+DT <- DT[year(datetime) == 2016]
+
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 

--- a/man/direction_to_centroid.Rd
+++ b/man/direction_to_centroid.Rd
@@ -101,13 +101,17 @@ and an error is returned.
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
-
+\dontshow{
+# (Subset example data to reduce runtime on CRAN)
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Temporal grouping
 group_times(DT, datetime = 'datetime', threshold = '20 minutes')
 

--- a/man/direction_to_leader.Rd
+++ b/man/direction_to_leader.Rd
@@ -105,13 +105,14 @@ and an error is returned.
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-
+\dontshow{
 # (Subset example data to reduce runtime on CRAN)
-DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
-
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 

--- a/man/distance_to_centroid.Rd
+++ b/man/distance_to_centroid.Rd
@@ -116,13 +116,14 @@ Note: in both cases, if the coordinates are NA then the result will be NA.
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
-
+\dontshow{
 # (Subset example data to reduce runtime on CRAN)
-DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
-
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
 

--- a/man/distance_to_centroid.Rd
+++ b/man/distance_to_centroid.Rd
@@ -121,7 +121,7 @@ library(data.table)
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 
 # (Subset example data to reduce runtime on CRAN)
-DT <- DT[year(datetime) == 2016]
+DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
 
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]

--- a/man/distance_to_leader.Rd
+++ b/man/distance_to_leader.Rd
@@ -105,16 +105,17 @@ Note: in both cases, if the coordinates are NA then the result will be NA.
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
-
+\dontshow{
 # (Subset example data to reduce runtime on CRAN)
-DT <- DT[year(datetime) == 2016 & month(datetime) == 11]
-
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Temporal grouping
 group_times(DT, datetime = 'datetime', threshold = '20 minutes')
 

--- a/man/leader_direction_group.Rd
+++ b/man/leader_direction_group.Rd
@@ -107,16 +107,17 @@ their input DT with \code{\link[=get_geometry]{get_geometry()}}. To use this int
 # Load data.table
 library(data.table)
 \dontshow{data.table::setDTthreads(1)}
-
 # Read example data
 DT <- fread(system.file("extdata", "DT.csv", package = "spatsoc"))
 
-# (Subset example data to reduce example run time)
-DT <- DT[year(datetime) == 2016]
-
 # Cast the character column to POSIXct
 DT[, datetime := as.POSIXct(datetime, tz = 'UTC')]
-
+\dontshow{
+# (Subset example data to reduce runtime on CRAN)
+if (isFALSE(rlang::is_interactive())) {
+  DT <- DT[as.Date(datetime) == '2017-01-17']
+}
+}
 # Temporal grouping
 group_times(DT, datetime = 'datetime', threshold = '20 minutes')
 


### PR DESCRIPTION
Again reducing example runtimes for CRAN, this time with dontshow, checking not interactive, and smaller subset